### PR TITLE
feat: Tmap POI 검색 연동을 통한 실시간 지오코딩 및 날씨 조회 구현

### DIFF
--- a/apps/server/src/main/java/com/weanet/server/service/ExternalMapService.java
+++ b/apps/server/src/main/java/com/weanet/server/service/ExternalMapService.java
@@ -27,6 +27,40 @@ public class ExternalMapService {
     @Value("${tmap.api.url}")
     private String apiUrl;
 
+    @Value("${tmap.api.poi.url}")
+    private String poiApiUrl;
+
+    /**
+     * 장소 명칭(keyword)을 기반으로 좌표(위도, 경도)를 조회합니다.
+     */
+    public double[] getCoordinates(String keyword) {
+        try {
+            String url = UriComponentsBuilder.fromUriString(poiApiUrl)
+                    .queryParam("version", 1)
+                    .queryParam("searchKeyword", keyword)
+                    .queryParam("count", 1)
+                    .queryParam("appKey", apiKey)
+                    .build().toUriString();
+
+            Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+            if (response != null && response.containsKey("searchPoiInfo")) {
+                Map<String, Object> searchPoiInfo = (Map<String, Object>) response.get("searchPoiInfo");
+                Map<String, Object> pois = (Map<String, Object>) searchPoiInfo.get("pois");
+                List<Map<String, Object>> poiList = (List<Map<String, Object>>) pois.get("poi");
+
+                if (!poiList.isEmpty()) {
+                    Map<String, Object> firstPoi = poiList.get(0);
+                    double lat = Double.parseDouble((String) firstPoi.get("frontLat"));
+                    double lon = Double.parseDouble((String) firstPoi.get("frontLon"));
+                    return new double[]{lat, lon};
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Error searching coordinates for " + keyword + ": " + e.getMessage());
+        }
+        return new double[]{37.5665, 126.9780}; // 기본값 서울
+    }
+
     /**
      * Tmap 대중교통 경로 검색 API를 호출합니다.
      */

--- a/apps/server/src/main/java/com/weanet/server/service/WeatherService.java
+++ b/apps/server/src/main/java/com/weanet/server/service/WeatherService.java
@@ -22,6 +22,7 @@ public class WeatherService {
 
     private final RestTemplate restTemplate;
     private final KmaCoordinateConverter coordinateConverter;
+    private final ExternalMapService externalMapService;
 
     @Value("${weather.api.key}")
     private String apiKey;
@@ -33,12 +34,8 @@ public class WeatherService {
      * 도시 이름을 기반으로 날씨 정보를 조회합니다.
      */
     public WeatherResponse getWeather(String city) {
-        // 간단한 도시별 좌표 매핑 (현업에선 DB 연동 권장)
-        double lat = 37.5665; double lng = 126.9780; // 서울 기본
-        if ("Busan".equalsIgnoreCase(city)) { lat = 35.1796; lng = 129.0756; }
-        else if ("Incheon".equalsIgnoreCase(city)) { lat = 37.4563; lng = 126.7052; }
-
-        return getWeatherByCoordinates(lat, lng);
+        double[] coords = externalMapService.getCoordinates(city);
+        return getWeatherByCoordinates(coords[0], coords[1]);
     }
 
     /**

--- a/apps/server/src/main/resources/application.properties
+++ b/apps/server/src/main/resources/application.properties
@@ -7,6 +7,7 @@ weather.api.url=http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVila
 # Tmap API (Route & Subway Congestion)
 tmap.api.key=${TMAP_API_KEY:YOUR_TMAP_API_KEY}
 tmap.api.url=https://apis.openapi.sk.com/transit/routes
+tmap.api.poi.url=https://apis.openapi.sk.com/tmap/pois
 subway.congestion.api.url=https://apis.openapi.sk.com/puzzle/subway/congestion/rltm/trains
 
 # Public Data API (Bus Congestion)


### PR DESCRIPTION
- ExternalMapService에 Tmap 통합 검색(POI) API 연동 로직 추가
- WeatherService의 하드코딩된 도시 좌표 매핑을 실시간 검색 기반으로 교체
- 클라이언트 날씨 위젯에 실제 서버 API 연동 및 로딩/에러 처리 적용
- 검색어(한글/영문)에 따른 동적 좌표 추출로 전국 날씨 조회 기능 지원

# 🔨 테스크

<!-- 이슈에 대한 작업이라면 PR과 이슈 연결 -->

### Issue

-   #72

### 소주제1

-   작업 이유와 작업에 대해 고민했던 점 작성하기

### 소주제2

-   작업 이유와 작업에 대해 고민했던 점 작성하기

# 📋 작업 내용

-   이번 테스크에서 작업한 내용을 적어주세요.

# 📷 스크린 샷(선택 사항)

동작 화면 첨부

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 날씨 조회 시 도시 이름으로 자동 위치를 검색하여 정보를 제공하는 기능이 추가되었습니다.
  * 기존에는 사전에 등록된 특정 도시들의 날씨만 조회할 수 있었으나, 이제는 사용자가 원하는 모든 도시의 날씨 정보를 조회할 수 있게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->